### PR TITLE
fix typo

### DIFF
--- a/docs/components/Toast.md
+++ b/docs/components/Toast.md
@@ -32,7 +32,7 @@ render() {
         &lt;/Header>
         &lt;Content padder>
           &lt;Button onPress={()=> Toast.show({
-              supportedOrientations={['potrait','landscape']}
+              supportedOrientations: ['potrait','landscape'],
               text: 'Wrong password!',
               position: 'bottom',
               buttonText: 'Okay'


### PR DESCRIPTION
I think it should be 
```
supportedOrientations: ['potrait','landscape'],
```
instead of 
```
supportedOrientations={['potrait','landscape']}
```
which doesn't compile