### PR TITLE
Update Toast.md Documentation with Styling Props

### DIFF
--- a/docs/components/Toast.md
+++ b/docs/components/Toast.md
@@ -90,6 +90,30 @@ export default class ToastExample extends Component &lcub;
                 <td> integer </td>
                 <td>Milliseconds after which Toast disappers</td>
             </tr>
+            <tr>
+                <td>style</td>
+                <td> - </td>
+                <td> object </td>
+                <td>Styling for the Toast</td>
+            </tr>
+            <tr>
+                <td>textStyle</td>
+                <td> - </td>
+                <td> object </td>
+                <td>Styling for the Toast Text</td>
+            </tr>
+            <tr>
+                <td>buttonStyle</td>
+                <td> - </td>
+                <td> object </td>
+                <td>Styling for the Toast Button</td>
+            </tr>
+            <tr>
+                <td>buttonTextStyle</td>
+                <td> - </td>
+                <td> object </td>
+                <td>Styling for the Toast Button Text</td>
+            </tr>
             </tbody>
         </table><br />
 


### PR DESCRIPTION
added `style`, `textStyle`, `buttonStyle`, and `buttonTextStyle` to Toast configuration documentation per changes in [commit 65078ac](https://github.com/GeekyAnts/NativeBase/commit/65078ac649c6c7e1f8d0b4b2f98c4c86e75edc3a)