### PR TITLE
Update GetStarted.md

### DIFF
--- a/docs/GetStarted.md
+++ b/docs/GetStarted.md
@@ -52,7 +52,7 @@ NativeBase uses some custom fonts that can be loaded using **loadAsync** functio
 async componentWillMount() {
   await Expo.Font.loadAsync({
     'Roboto': require('native-base/Fonts/Roboto.ttf'),
-    'Roboto_medium': require('native-base/Fonts/Roboto_medium.ttf'),
+    'Roboto_medium': require('native-base/Fonts/Roboto_medium.ttf')
   });
 }
 ```


### PR DESCRIPTION
For a newBie who tries to follow this Get-started guide, when he tries to copy paste the custom font lines in his setup , he might face the following error 
                  **"fontFamily 'Roboto_medium' is not a system font and has not been loaded through Expo.Font.loadAsync. - If you intended to use a system font, make sure you typed the name correctly and that it is supported by your device operating system. - If this is a custom font, be sure to load it with Expo.Font.loadAsync. - node_modules\react-native\Libraries\ReactNative\YellowBox.js:71:16 in error - node_modules\expo\src\Font.js:34:10 in processFontFamily - ... 28 more stack frames from framework internals"** 

even after linking with react-native link step  because of this **unwanted comma** in the last line.

So to make this guide more accurate and seamless we can remove the unwanted comma 

