### PR TITLE
Fixing missing call to super in constructor

### DIFF
--- a/docs/components/FABs.md
+++ b/docs/components/FABs.md
@@ -13,6 +13,7 @@ Replacing Component: React Native [Animated](http://facebook.github.io/react-nat
 import { Container, Header, View, Button, Icon, Fab } from 'native-base';
 export default class FABExample extends Component {
   constructor() {
+    super();
     this.state = {
       active: 'true'
     };
@@ -110,6 +111,7 @@ export default class FABExample extends Component {
 import { Container, Header, View, Fab, Button, Icon } from 'native-base';
 ​export default class FABMultipleExample extends Component {
   constructor() {
+    super();
     this.state = {
       active: 'true'
     };


### PR DESCRIPTION
This pull request contains fix for missing call to super() in constructor for FABs sample code. Without call to super in contructor following error is generated while running the sample code.
<img width="381" alt="screen shot 2018-01-18 at 9 02 14 pm" src="https://user-images.githubusercontent.com/4947384/35105942-ef8e532e-fc92-11e7-8cb1-6d88ba6c8050.png">
Please find the stackoverflow thread for why we need to call super() in constructor before accessing  'this'
[Link](https://stackoverflow.com/questions/43539654/why-isnt-this-allowed-before-super) 