### PR TITLE
Shift to https

### DIFF
--- a/book.json
+++ b/book.json
@@ -27,7 +27,7 @@
       "theme": "monokai"
     },
     "versions": {
-      "gitbookConfigURL": "http://rawgit.com/GeekyAnts/native-base-docs/master/book.json",
+      "gitbookConfigURL": "https://rawgit.com/GeekyAnts/native-base-docs/master/book.json",
       "options": [
         {
           "value": "https://nativebase.io/docs/v2.0.0/",
@@ -35,43 +35,43 @@
           "selected": true
         },
         {
-          "value": "http://rawgit.com/GeekyAnts/native-base-docs/v2.0/_book/index.html",
+          "value": "https://rawgit.com/GeekyAnts/native-base-docs/v2.0/_book/index.html",
           "text": "v2.0.0"
         },
         {
-          "value": "http://nativebase.io/docs/v0.5.13/",
+          "value": "https://nativebase.io/docs/v0.5.13/",
           "text": "v0.5.13"
         },
         {
-          "value": "http://nativebase.io/docs/v0.5.9/",
+          "value": "https://nativebase.io/docs/v0.5.9/",
           "text": "v0.5.9"
         },
         {
-          "value": "http://nativebase.io/docs/v0.5.7/",
+          "value": "https://nativebase.io/docs/v0.5.7/",
           "text": "v0.5.7"
         },
         {
-          "value": "http://nativebase.io/docs/v0.5.5/",
+          "value": "https://nativebase.io/docs/v0.5.5/",
           "text": "v0.5.5"
         },
         {
-          "value": "http://nativebase.io/docs/v0.5.2/",
+          "value": "https://nativebase.io/docs/v0.5.2/",
           "text": "v0.5.2"
         },
         {
-          "value": "http://nativebase.io/docs/v0.5.0/",
+          "value": "https://nativebase.io/docs/v0.5.0/",
           "text": "v0.5.0"
         },
         {
-          "value": "http://nativebase.io/docs/v0.4.6/",
+          "value": "https://nativebase.io/docs/v0.4.6/",
           "text": "v0.4.6"
         },
         {
-          "value": "http://nativebase.io/docs/v0.3.1/",
+          "value": "https://nativebase.io/docs/v0.3.1/",
           "text": "v0.3.1"
         },
         {
-          "value": "http://nativebase.io/docs/v0.3.0/",
+          "value": "https://nativebase.io/docs/v0.3.0/",
           "text": "v0.3.0"
         }
       ]


### PR DESCRIPTION
In recent Chrome, a small popup warn user that doc page is trying to load contents from a non-secure page.

It's related to the row

`"gitbookConfigURL": "https://rawgit.com/GeekyAnts/native-base-docs/master/book.json",`

So I catch the occasion to change all url to https