### PR TITLE
Added button to thumbnail list item.

### DIFF
--- a/_book/Components.html
+++ b/_book/Components.html
@@ -4499,7 +4499,7 @@ To have note kind of text for list item, include <code>note</code> prop with <co
 <img src="https://github.com/GeekyAnts/NativeBase-KitchenSink/raw/v2.2.0/screenshots/android/list-thumbnail.png" alt="Preview android list-thumbnail-headref"></p>
 <p><em>Syntax</em></p>
 <p><pre class="line-numbers"><code class="language-jsx"><span class="hljs-keyword">import</span> React, { Component } <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;react&apos;</span>;
-<span class="hljs-keyword">import</span> { Container, Header, Content, List, ListItem, Thumbnail, Text, Body } <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;native-base&apos;</span>;
+<span class="hljs-keyword">import</span> { Container, Header, Content, List, ListItem, Thumbnail, Text, Body, Right } <span class="hljs-keyword">from</span> <span class="hljs-string">&apos;native-base&apos;</span>;
 <span class="hljs-keyword">export</span> <span class="hljs-keyword">default</span> <span class="hljs-class"><span class="hljs-keyword">class</span> <span class="hljs-title">ListThumbnailExample</span> <span class="hljs-keyword">extends</span> <span class="hljs-title">Component</span> </span>{
   render() {
     <span class="hljs-keyword">return</span> (
@@ -4513,6 +4513,11 @@ To have note kind of text for list item, include <code>note</code> prop with <co
                 &lt;Text&gt;Sankhadeep&lt;/Text&gt;
                 &lt;Text note&gt;Its time to build a difference . .&lt;/Text&gt;
               &lt;/Body&gt;
+              &lt;Right&gt;
+                &lt;Button transparent&gt;
+                  &lt;Text>View&lt;/Text&gt;
+                &lt;/Button&gt;
+              &lt;/Right&gt;
             &lt;/ListItem&gt;
           &lt;/List&gt;
         &lt;/Content&gt;

--- a/_book/Components.html
+++ b/_book/Components.html
@@ -4515,7 +4515,7 @@ To have note kind of text for list item, include <code>note</code> prop with <co
               &lt;/Body&gt;
               &lt;Right&gt;
                 &lt;Button transparent&gt;
-                  &lt;Text>View&lt;/Text&gt;
+                  &lt;Text&gt;View&lt;/Text&gt;
                 &lt;/Button&gt;
               &lt;/Right&gt;
             &lt;/ListItem&gt;

--- a/docs/components/list/ListThumbnail.md
+++ b/docs/components/list/ListThumbnail.md
@@ -10,7 +10,7 @@ List Thumbnails are the medium to exhibit an image with your list item. To creat
 *Syntax*
 
 <pre class="line-numbers"><code class="language-jsx">import React, { Component } from 'react';
-import { Container, Header, Content, List, ListItem, Thumbnail, Text, Body } from 'native-base';
+import { Container, Header, Content, List, ListItem, Thumbnail, Text, Body, Right } from 'native-base';
 export default class ListThumbnailExample extends Component {
   render() {
     return (
@@ -24,6 +24,11 @@ export default class ListThumbnailExample extends Component {
                 &lt;Text>Sankhadeep&lt;/Text>
                 &lt;Text note>Its time to build a difference . .&lt;/Text>
               &lt;/Body>
+              &lt;Right>
+                &lt;Button transparent>
+                  &lt;Text>View&lt;/Text>
+                &lt;/Button>
+              &lt;/Right>
             &lt;/ListItem>
           &lt;/List>
         &lt;/Content>


### PR DESCRIPTION
The "Thumbnail list" item had omitted both the button in the picture and the right element the button was supposed to be nested into. I've added both of these, hopefully they save someone in the future some time. It took me a bit to actually figure out that the text link was a transparent button rather than some sort of link or label.