### PR TITLE
First argument of render methods is current dataArray item

### DIFF
--- a/_book/docs/components/accordion/AccordionCustomHeaderContent.md
+++ b/_book/docs/components/accordion/AccordionCustomHeaderContent.md
@@ -16,7 +16,7 @@ const dataArray = [
   { title: "Third Element", content: "Lorem ipsum dolor sit amet" }
 ];
 export default class AccordionCustomHeaderContentExample extends Component {
-  _renderHeader({title, expanded}) {
+  _renderHeader({title}, expanded) {
     return (
       <View
         {% raw %}style={{ flexDirection: "row", padding: 10, justifyContent: "space-between", alignItems: "center", backgroundColor: "#A9DAD6" }}{% endraw %}

--- a/_book/docs/components/accordion/AccordionCustomHeaderContent.md
+++ b/_book/docs/components/accordion/AccordionCustomHeaderContent.md
@@ -16,7 +16,7 @@ const dataArray = [
   { title: "Third Element", content: "Lorem ipsum dolor sit amet" }
 ];
 export default class AccordionCustomHeaderContentExample extends Component {
-  _renderHeader(title, expanded) {
+  _renderHeader({title, expanded}) {
     return (
       <View
         {% raw %}style={{ flexDirection: "row", padding: 10, justifyContent: "space-between", alignItems: "center", backgroundColor: "#A9DAD6" }}{% endraw %}
@@ -30,7 +30,7 @@ export default class AccordionCustomHeaderContentExample extends Component {
       </View>
     );
   }
-  _renderContent(content) {
+  _renderContent({content}) {
     return (
       <Text
         {% raw %}style={{ backgroundColor: "#e3f1f1", padding: 10, fontStyle: "italic" }}{% endraw %}

--- a/docs/components/accordion/AccordionCustomHeaderContent.md
+++ b/docs/components/accordion/AccordionCustomHeaderContent.md
@@ -16,7 +16,7 @@ const dataArray = [
   { title: "Third Element", content: "Lorem ipsum dolor sit amet" }
 ];
 export default class AccordionCustomHeaderContentExample extends Component {
-  _renderHeader({title, expanded}) {
+  _renderHeader({title}, expanded) {
     return (
       <View
         {% raw %}style={{ flexDirection: "row", padding: 10, justifyContent: "space-between", alignItems: "center", backgroundColor: "#A9DAD6" }}{% endraw %}

--- a/docs/components/accordion/AccordionCustomHeaderContent.md
+++ b/docs/components/accordion/AccordionCustomHeaderContent.md
@@ -16,7 +16,7 @@ const dataArray = [
   { title: "Third Element", content: "Lorem ipsum dolor sit amet" }
 ];
 export default class AccordionCustomHeaderContentExample extends Component {
-  _renderHeader(title, expanded) {
+  _renderHeader({title, expanded}) {
     return (
       <View
         {% raw %}style={{ flexDirection: "row", padding: 10, justifyContent: "space-between", alignItems: "center", backgroundColor: "#A9DAD6" }}{% endraw %}
@@ -30,7 +30,7 @@ export default class AccordionCustomHeaderContentExample extends Component {
       </View>
     );
   }
-  _renderContent(content) {
+  _renderContent({content}) {
     return (
       <Text
         {% raw %}style={{ backgroundColor: "#e3f1f1", padding: 10, fontStyle: "italic" }}{% endraw %}


### PR DESCRIPTION
Current dataArray item (in our example case: object i.e `{ title: "First Element", content: "Lorem ipsum dolor sit amet" }` ) is passed as first argument to the render methods (in our example case: `_renderHeader` and `_renderContent`)