### PR TITLE
Critical fix on DeckSwiper Docs. (Closing bracket was missing).

### DIFF
--- a/docs/components/DeckSwiper.md
+++ b/docs/components/DeckSwiper.md
@@ -234,6 +234,7 @@ export default class DeckSwiperAdvancedExample extends Component {
               {% raw %}<View style={{ alignSelf: "center" }}>{% endraw %}
                 <Text>Over</Text>
               </View>
+            }
             renderItem={item =>
               {% raw %}<Card style={{ elevation: 3 }}>{% endraw %}
                 <CardItem>


### PR DESCRIPTION
I accidentally found this bug in the documentation, while following them to get started. After investing more than an hour I got it resolved for my case. Thus I preferred to update here, so others will get it perfectly.