### PR TITLE
Removing this binding in DatePicker

### DIFF
--- a/docs/components/DatePicker.md
+++ b/docs/components/DatePicker.md
@@ -13,7 +13,6 @@ export default class DatePickerExample extends Component {
   constructor(props) {
     super(props);
     this.state = { chosenDate: new Date() };
-    this.setDate = this.setDate.bind(this);
   }
   setDate(newDate) {
     this.setState({ chosenDate: newDate });
@@ -35,7 +34,7 @@ export default class DatePickerExample extends Component {
             placeHolderText="Select date"
             {% raw %}textStyle={{ color: "green" }}{% endraw %}
             {% raw %}placeHolderTextStyle={{ color: "#d3d3d3" }}{% endraw %}
-            onDateChange={this.setDate}
+            onDateChange={() => {this.setDate}}
             />
             <Text>
               Date: {this.state.chosenDate.toString().substr(4, 12)}


### PR DESCRIPTION
instead of binding `this` to `setDate` and reassign it to `setDate`, just put the arrow function in `onDateChange`. 
it is more easy, understandable and readable to all programmers.