### PR TITLE
Update AccordionCustomHeaderContent.md

### DIFF
--- a/docs/components/accordion/AccordionCustomHeaderContent.md
+++ b/docs/components/accordion/AccordionCustomHeaderContent.md
@@ -16,7 +16,7 @@ const dataArray = [
   { title: "Third Element", content: "Lorem ipsum dolor sit amet" }
 ];
 export default class AccordionCustomHeaderContentExample extends Component {
-  _renderHeader(title, expanded) {
+  _renderHeader({title}, expanded) {
     return (
       <View
         {% raw %}style={{ flexDirection: "row", padding: 10, justifyContent: "space-between", alignItems: "center", backgroundColor: "#A9DAD6" }}{% endraw %}
@@ -30,7 +30,7 @@ export default class AccordionCustomHeaderContentExample extends Component {
       </View>
     );
   }
-  _renderContent(content) {
+  _renderContent({content}) {
     return (
       <Text
         {% raw %}style={{ backgroundColor: "#e3f1f1", padding: 10, fontStyle: "italic" }}{% endraw %}


### PR DESCRIPTION
throws error when content and title are not explicitly password as params in _renderContent and _renderHeader methods respectively

error is : Invariant Violation: Invariant Violation: Objects are not valid as a React child (found: object with keys {title,content}). If you meant to render a collection of children, use an array instead.