### PR TITLE
Fix Drawer example

### DIFF
--- a/docs/components/Drawer.md
+++ b/docs/components/Drawer.md
@@ -13,13 +13,15 @@ Replacing Component: [React Native Drawer](https://github.com/root-two/react-nat
 import { Drawer } from 'native-base';
 import SideBar from './yourPathToSideBar';
 export default class DrawerExample extends Component {
+  closeDrawer () => {
+    this.drawer._root.close()
+  };
+  
+  openDrawer () => {
+    this.drawer._root.open()
+  };
+
   render() {
-    closeDrawer = () => {
-      this.drawer._root.close()
-    };
-    openDrawer = () => {
-      this.drawer._root.open()
-    };
     return (
       &lt;Drawer
         ref={(ref) => { this.drawer = ref; }}


### PR DESCRIPTION
`closeDrawer` and `openDrawer` are inside the render method, but then called as `this. closeDrawer`. This just moves them out of the render method in the example.