### PR TITLE
Fix incorrect brace character in `Picker` docs

### DIFF
--- a/docs/components/picker/Picker-With-Custom-Header-Style.md
+++ b/docs/components/picker/Picker-With-Custom-Header-Style.md
@@ -27,7 +27,7 @@ export default class PickerCustomHeaderStyleExample extends Component {
           <Form>
             <Picker
               mode="dropdown"
-              {% raw %}iosIcon={{Icon name="arrow-down" />}{% endraw %}
+              {% raw %}iosIcon={<Icon name="arrow-down" />}{% endraw %}
               {% raw %}headerStyle={{ backgroundColor: "#b95dd3" }}{% endraw %}
               {% raw %}headerBackButtonTextStyle={{ color: "#fff" }}{% endraw %}
               {% raw %}headerTitleStyle={{ color: "#fff" }}{% endraw %}


### PR DESCRIPTION
The brace character should be an angle-bracket/less-than sign.