### PR TITLE
Typo - update Accordion.md

### DIFF
--- a/docs/components/accordion/Accordion.md
+++ b/docs/components/accordion/Accordion.md
@@ -103,13 +103,13 @@ export default {
         </tr>
         <tr>
             <td>icon</td>
-            <td>arrow-up</td>
+            <td>arrow-down</td>
             <td>user-defined</td>
             <td>Icon when accordion is closed</td>
         </tr>
         <tr>
             <td>expandedIcon</td>
-            <td>arrow-down</td>
+            <td>arrow-up</td>
             <td>user-defined</td>
             <td>Icon when accordion is open</td>
         </tr>


### PR DESCRIPTION
The sample graphic for the "Accordion" component indicates that "arrow-down" is for closed and "arrow-up" is for open, which is also logical behavior. The docs indicate the opposite.

Note, I have not used NativeBase. I was looking through the docs while considering to use it and noticed what appears to be this typo.