### PR TITLE
Corrected default FAB state from String to Boolean

### DIFF
--- a/docs/components/FABs.md
+++ b/docs/components/FABs.md
@@ -16,7 +16,7 @@ export default class FABExample extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      active: 'true'
+      active: false
     };
   }
   render() {
@@ -161,7 +161,7 @@ import { Container, Header, View, Fab, Button, Icon } from 'native-base';
   constructor(props) {
     super(props)
     this.state = {
-      active: 'true'
+      active: false
     };
   }
   render() {


### PR DESCRIPTION
Changed the default FAB state in the component documentation example from a String to inactive which matches with the existing screenshots