### PR TITLE
Updated Getting Started for newer version of Expo

### DIFF
--- a/docs/GetStarted.md
+++ b/docs/GetStarted.md
@@ -67,6 +67,7 @@ expo install expo-font
 *App.js* <br />
 ```js
 import React from 'react';
+import { AppLoading } from 'expo';
 import { Container, Text } from 'native-base';
 import * as Font from 'expo-font';
 import { Ionicons } from '@expo/vector-icons';

--- a/docs/GetStarted.md
+++ b/docs/GetStarted.md
@@ -59,19 +59,46 @@ yarn add native-base --save
 NativeBase use some custom fonts that can be loaded using **Font.loadAsync** function. Check out the [Expo Font documentation](https://docs.expo.io/versions/latest/sdk/font/).
 <br />
 
-*Syntax* <br />
+*Install Expo Fonts*
+```bash
+expo install expo-font
+```
+
+*App.js* <br />
 ```js
-// At the top of your file
-import { Font } from 'expo';
+import React from 'react';
+import { Container, Text } from 'native-base';
+import * as Font from 'expo-font';
 import { Ionicons } from '@expo/vector-icons';
 
-// Later on in your component
-async componentDidMount() {
-  await Font.loadAsync({
-    'Roboto': require('native-base/Fonts/Roboto.ttf'),
-    'Roboto_medium': require('native-base/Fonts/Roboto_medium.ttf'),
-    ...Ionicons.font,
-  });
+export default class App extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isReady: false,
+    };
+  }
+
+  async componentDidMount() {
+    await Font.loadAsync({
+      Roboto: require('native-base/Fonts/Roboto.ttf'),
+      Roboto_medium: require('native-base/Fonts/Roboto_medium.ttf'),
+      ...Ionicons.font,
+    });
+    this.setState({ isReady: true });
+  }
+
+  render() {
+    if (!this.state.isReady) {
+      return <AppLoading />;
+    }
+
+    return (
+      <Container>
+        <Text>Open up App.js to start working on your app!</Text>
+      </Container>
+    );
+  }
 }
 ```
 <br />


### PR DESCRIPTION
The latest version of Expo requires `expo-font` to be installed separately and awaited before the container loads like the [kitchen sink app](https://github.com/GeekyAnts/NativeBase-KitchenSink/blob/CRNA/src/boot/setup.js) does.

Related https://github.com/GeekyAnts/NativeBase/pull/2738