### PR TITLE
fix drawer code section rendering problem

### DIFF
--- a/docs/components/Drawer.md
+++ b/docs/components/Drawer.md
@@ -16,11 +16,9 @@ export default class DrawerExample extends Component {
   closeDrawer () => {
     this.drawer._root.close()
   };
-  
   openDrawer () => {
     this.drawer._root.open()
   };
-
   render() {
     return (
       &lt;Drawer
@@ -90,4 +88,3 @@ export default class DrawerExample extends Component {
             </tr>
         </tbody>
     </table><br />
-


### PR DESCRIPTION
Hi! I checked both on Chrome 75.0.3770.142  and Firefox 68.0.1.

The new lines in the code section break the style.

![Screenshot from 2019-07-30 21-14-44](https://user-images.githubusercontent.com/10065235/62155237-0323bb00-b311-11e9-9ea1-cead2b6b7969.png)
