### PR TITLE
fix: yarn add command

### DIFF
--- a/docs/GetStarted.md
+++ b/docs/GetStarted.md
@@ -53,7 +53,7 @@ Refer this link for additional information on [Expo](https://docs.expo.io/)
 
 *Install NativeBase*
 ```js
-yarn add native-base --save
+yarn add native-base
 ```
 
 NativeBase use some custom fonts that can be loaded using **Font.loadAsync** function. Check out the [Expo Font documentation](https://docs.expo.io/versions/latest/sdk/font/).


### PR DESCRIPTION
Adding a `--save` when installing a dependency with `yarn add` does not do anything. Reference: [yarn official docs](https://yarnpkg.com/lang/en/docs/cli/install/).

IMO, it will be better to remove the flag `--save` from the `yarn` command in this document. 

PS: Just trying to improve docs.